### PR TITLE
Alteração para permitir iniciar ORPActivity por objeto Context.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         maven { url 'https://jitpack.io' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.2'
+        classpath 'com.android.tools.build:gradle:2.3.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -9,8 +9,8 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 24
-        versionCode 2
-        versionName "1.0.4"
+        versionCode 3
+        versionName "1.0.6"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 
@@ -36,7 +36,7 @@ ext {
     siteUrl = 'https://github.com/aistech/orp'
     gitUrl = 'https://github.com/aistech/orp.git'
 
-    libraryVersion = '1.0.2'
+    libraryVersion = '1.0.6'
 
     developerId = 'aistech'
     developerName = 'Jonathan Nobre Ferreira'

--- a/library/src/main/java/com/github/aistech/orp/activities/ORPActivity.java
+++ b/library/src/main/java/com/github/aistech/orp/activities/ORPActivity.java
@@ -25,10 +25,10 @@ public abstract class ORPActivity extends AppCompatActivity implements ORProtoco
     public static final String TAG = ORPActivity.class.getSimpleName();
 
     /**
-     * This constant is used recover the Caller (or if you want, origin) activity's hashCode who started
+     * This constant is used to recover the caller (or if you prefer, origin) activity's hashCode who started
      * the current activity. This code is used to recover the extra parameters sent to the current activity.
      */
-    public static final String HASH_CODE_EXTRA = ORPActivity.class.getName().concat("originActivityHashCode");
+    public static final String HASH_CODE_EXTRA = ORPActivity.class.getName().concat("originalCallerHashCode");
 
     private Integer activityCallerHashCode;
 

--- a/library/src/main/java/com/github/aistech/orp/builder/ORPBuilder.java
+++ b/library/src/main/java/com/github/aistech/orp/builder/ORPBuilder.java
@@ -1,5 +1,6 @@
 package com.github.aistech.orp.builder;
 
+import android.content.Context;
 import android.content.Intent;
 
 import com.github.aistech.orp.activities.ORPActivity;
@@ -16,7 +17,7 @@ import java.util.Map;
 
 public class ORPBuilder {
 
-    private ORPActivity originActivity;
+    private Context origin;
     private Class<? extends ORPActivity> destinationActivity;
 
     private Map<String, Object> parameters;
@@ -24,10 +25,15 @@ public class ORPBuilder {
     /**
      * You shall init this builder passing the origin activity, a.k.a the source Activity.
      *
-     * @param originActivity
+     * @param origin
      */
-    public ORPBuilder(ORPActivity originActivity) {
-        this.originActivity = originActivity;
+    public ORPBuilder(ORPActivity origin) {
+        this.origin = origin;
+        this.parameters = new LinkedHashMap<>();
+    }
+
+    public ORPBuilder(Context origin) {
+        this.origin = origin;
         this.parameters = new LinkedHashMap<>();
     }
 
@@ -64,9 +70,9 @@ public class ORPBuilder {
      * @return
      */
     public Intent build() {
-        ORPSingleton.getInstance().addOriginActivity(this.originActivity, this.parameters);
-        Intent intent = new Intent(this.originActivity, this.destinationActivity);
-        intent.putExtra(ORPActivity.HASH_CODE_EXTRA, this.originActivity.hashCode());
+        ORPSingleton.getInstance().addOriginActivity(this.origin, this.parameters);
+        Intent intent = new Intent(this.origin, this.destinationActivity);
+        intent.putExtra(ORPActivity.HASH_CODE_EXTRA, this.origin.hashCode());
         return intent;
     }
 
@@ -75,6 +81,6 @@ public class ORPBuilder {
      * {#link {@link android.content.Context#startActivity} method, don't worry, here it is.
      */
     public void start() {
-        this.originActivity.startActivity(build());
+        this.origin.startActivity(build());
     }
 }

--- a/library/src/main/java/com/github/aistech/orp/singletons/ORPSingleton.java
+++ b/library/src/main/java/com/github/aistech/orp/singletons/ORPSingleton.java
@@ -1,5 +1,7 @@
 package com.github.aistech.orp.singletons;
 
+import android.content.Context;
+
 import com.github.aistech.orp.activities.ORPActivity;
 import com.github.aistech.orp.exceptions.ORPExceptions;
 
@@ -8,7 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * The All Might Singleton that will handle all your sins and misbehavior...no...just kidding,
+ * The almighty Singleton that will handle all your sins and misbehavior...no...just kidding,
  * this will only help you recover the object reference while using the {@link com.github.aistech.orp.builder.ORPBuilder}.
  * <p>
  * For your sins, well, may God have mercy on your soul.
@@ -34,13 +36,13 @@ public final class ORPSingleton {
     }
 
     /**
-     * As the method name says..you should add the origin class, or, the source activity.
+     * As the method name says...you should add the origin class, or, the source activity.
      *
-     * @param originActivity
+     * @param origin
      * @param parameters
      */
-    public void addOriginActivity(ORPActivity originActivity, Map<String, Object> parameters) {
-        Integer hashCode = originActivity.hashCode();
+    public void addOriginActivity(Context origin, Map<String, Object> parameters) {
+        Integer hashCode = origin.hashCode();
         Map<String, Object> recoveredParameters = this.parametersMap.get(hashCode);
         if (recoveredParameters == null) {
             recoveredParameters = new LinkedHashMap<>();


### PR DESCRIPTION
Alteração permite lançamento de activities por services --ou mais genericamente-- objetos que são também Context. Permite assim simplificar o código do ORPActivity, que não precisará testar como eles foram chamados para instanciar os objetos passados.